### PR TITLE
Update sample.js to fix the colours for the chart

### DIFF
--- a/client/app/sample.js
+++ b/client/app/sample.js
@@ -22,7 +22,7 @@
 	        	var data = ko.toJS(options.data).map(function(x) {
 	        		return {
 	        			value: parseFloat(x.value),
-	        			color: x.color.indexOf('#') === 0 ? "#" + x.color : x.color
+	        			color: x.color.indexOf('#') === 0 ? x.color : "#" + x.color
 	        		}
 	        	});
 


### PR DESCRIPTION
I fixed the logic to add the '#' if it is not in the colour so that the colours in the chart work.  It was flawed in that it would add the '#' only if the colour already starts with it.
