### PR TITLE
Chart colours now display

### DIFF
--- a/client/app/sample.js
+++ b/client/app/sample.js
@@ -23,7 +23,7 @@
 	        	var data = ko.toJS(options.data).map(function(x) {
 	        		return {
 	        			value: parseFloat(x.value),
-	        			color: x.color.indexOf('#') === 0 ? "#" + x.color : x.color
+	        			color: x.color.indexOf('#') === 0 ? x.color : "#" + x.color
 	        		}
 	        	});
 


### PR DESCRIPTION
Fixed the logic in the chart colours so that they display.  The flaw was the same as in my other pull request where the '#' was only added if it already existed in the colour.
